### PR TITLE
Revert needlessly complex osu! directory lookup

### DIFF
--- a/Listen/OSUListenerManager.cs
+++ b/Listen/OSUListenerManager.cs
@@ -427,34 +427,12 @@ namespace OsuRTDataProvider.Listen
             _find_osu_process_timer += Setting.ListenInterval;
         }
 
-        private static string GetExecPath(Process process)
-        {
-            var wmiQueryString = $"SELECT ProcessId, ExecutablePath, CommandLine FROM Win32_Process WHERE ProcessId = {process.Id}";
-            using (var searcher = new ManagementObjectSearcher(wmiQueryString))
-            using (var results = searcher.Get())
-            {
-                var query = from p in Process.GetProcesses()
-                            join mo in results.Cast<ManagementObject>()
-                            on p.Id equals (int)(uint)mo["ProcessId"]
-                            select new
-                            {
-                                Process = p,
-                                Path = (string)mo["ExecutablePath"],
-                                CommandLine = (string)mo["CommandLine"],
-                            };
-                var path = query.FirstOrDefault(p => p.Process.Id == process.Id)?.Path ?? null;
-                return path;
-            }
-        }
-
         private void FindOsuSongPath()
         {
             string osu_path = "";
             try
             {
-                string osu_exec_path = GetExecPath(m_osu_process);
-                if (osu_exec_path == null) return;
-                osu_path = Path.GetDirectoryName(osu_exec_path);
+                osu_path = Path.GetDirectoryName(m_osu_process.MainModule.FileName);
                 string osu_config_file = Path.Combine(osu_path, $"osu!.{PathHelper.WindowsPathStrip(Environment.UserName)}.cfg");
                 string song_path;
 


### PR DESCRIPTION
I'm not sure why this change was introduced in https://github.com/OsuSync/OsuRTDataProvider/commit/5f189a4c82511a831aa96a0ad4338e81729cc5ca as that part doesn't seem to be the one relevant to that particular bug, as far as I'm aware.

Wine does not implement WMI queries and therefore makes ORTDP crash. Reverting back to the prior implementation of the osu! directory lookup fixed Wine support.

Ideally, we'd want this kind of bugs fixed in Wine instead, but I needed a quick fix and I don't have the appropriate skills to work on such Wine feature, so I patched it here instead. I'm submitting this workaround as I believe this would improve the code quality of this project and thus makes it a legitimate patch. Unless there's an actual reason behind using WMI queries.