### PR TITLE
Fix performance issues

### DIFF
--- a/Memory/OsuBeatmapFinder.cs
+++ b/Memory/OsuBeatmapFinder.cs
@@ -32,7 +32,7 @@ namespace OsuRTDataProvider.Memory
         private const int MAX_RETRY_COUNT = 10;
 
         private IntPtr m_beatmap_address;
-        private byte[] s_beatmap_pattern_bytes;
+        private static byte[] s_beatmap_pattern_bytes;
 
         public OsuBeatmapFinder(Process osu) : base(osu)
         {

--- a/Memory/OsuBeatmapFinder.cs
+++ b/Memory/OsuBeatmapFinder.cs
@@ -32,7 +32,8 @@ namespace OsuRTDataProvider.Memory
         private const int MAX_RETRY_COUNT = 10;
 
         private IntPtr m_beatmap_address;
-        
+        private byte[] s_beatmap_pattern_bytes;
+
         public OsuBeatmapFinder(Process osu) : base(osu)
         {
             var versionBeatmapOffset = BeatmapOffsetInfo.MatchVersion(Setting.CurrentOsuVersionValue);
@@ -47,7 +48,7 @@ namespace OsuRTDataProvider.Memory
             SigScan.Reload();
             {
                 //Find Beatmap ID Address
-                m_beatmap_address = SigScan.FindPattern(StringToByte(s_beatmap_pattern), s_beatmap_mask, 4);
+                m_beatmap_address = SigScan.FindPattern(s_beatmap_pattern_bytes = s_beatmap_pattern_bytes ?? StringToByte(s_beatmap_pattern), s_beatmap_mask, 4);
                 LogHelper.LogToFile($"Beatmap Base Address (0):0x{(int)m_beatmap_address:X8}");
 
                 success = TryReadIntPtrFromMemory(m_beatmap_address, out m_beatmap_address);

--- a/Memory/OsuFinderBase.cs
+++ b/Memory/OsuFinderBase.cs
@@ -39,9 +39,12 @@ namespace OsuRTDataProvider.Memory
 
         protected byte[] StringToByte(string s)
         {
-            _a.Clear();
-            foreach (var c in s) _a.Add((byte)c);
-            return _a.ToArray();
+            lock (_a)
+            {
+                _a.Clear();
+                foreach (var c in s) _a.Add((byte)c);
+                return _a.ToArray();
+            }
         }
 
         private byte[] _number_buf = new byte[8];

--- a/Memory/OsuHitEventFinder.cs
+++ b/Memory/OsuHitEventFinder.cs
@@ -80,18 +80,18 @@ namespace OsuRTDataProvider.Memory
         // 74 4D A1 ?? ?? ?? ?? 8B 58 34 8D 46 FF
         // A1 ?? ?? ?? ?? 8B 40 34 8B 70 0C 
         // 75 0E 33 D2 89 15 ?? ?? ?? ?? 89 15
-        internal override string[] pattern => new string[] {
+        internal override string[] pattern { get; } = new string[] {
             "\xD9\x5D\xC0\xEB\x4E\xA1\x00\x00\x00\x00\x8B\x48\x34\x4E",
             "\x74\x4D\xA1\x00\x00\x00\x00\x8B\x58\x34\x8D\x46\xFF",
             "\xA1\x00\x00\x00\x00\x8B\x40\x34\x8B\x70\x0C",
             "\x75\x0E\x33\xD2\x89\x15\x0\x0\x0\x0\x89\x15"
         };
 
-        internal override string[] mask => new string[] { 
+        internal override string[] mask { get; } = new string[] {
             "xxxxxx????xxxx", "xxx????xxxxxx", "x????xxxxxx", "xxxxxx????xx"
         };
 
-        internal override int[] offset => new int[] { 6, 3, 1, 6 };
+        internal override int[] offset { get; } = new int[] { 6, 3, 1, 6 };
 
         internal override string name => "Replay";
 
@@ -104,16 +104,16 @@ namespace OsuRTDataProvider.Memory
     {
         // 83 7E 60 00 74 2C A1 ?? ?? ?? ?? 8B 50 1C 8B 4A 04
         // 5D C3 A1 ?? ?? ?? ?? 8B 50 1C 8B 4A 04
-        internal override string[] pattern => new string[] {
+        internal override string[] pattern { get; } = new string[] {
             "\x83\x7E\x60\x00\x74\x2C\xA1\x00\x00\x00\x00\x8B\x50\x1C\x8B\x4A\x04",
             "\x5D\xC3\xA1\x00\x00\x00\x00\x8B\x50\x1C\x8B\x4A\x04"
         };
 
-        internal override string[] mask => new string[] {
+        internal override string[] mask { get; } = new string[] {
             "xxxxxxx????xxxxxx", "xxx????xxxxxx"
         };
 
-        internal override int[] offset => new int[] { 7, 3 };
+        internal override int[] offset { get; } = new int[] { 7, 3 };
 
         internal override string name => "Playing";
 
@@ -129,6 +129,7 @@ namespace OsuRTDataProvider.Memory
         int[] PreOffsets = new int[4] { -1, -1, -1, -1 };
 
         internal abstract string[] pattern { get; }
+        internal List<byte[]> pattern_byte { get; private set; }
         internal abstract string[] mask { get; }
         internal abstract int[] offset { get; }
         internal abstract string name { get; }
@@ -155,12 +156,20 @@ namespace OsuRTDataProvider.Memory
         public override bool TryInit()
         {
             bool success = false;
+            if (pattern_byte == null)
+            {
+                pattern_byte = new List<byte[]>(pattern.Length);
+                foreach (var s in pattern)
+                {
+                    pattern_byte.Add(StringToByte(s));
+                }
+            }
 
             SigScan.Reload();
             {
-                for (int i = 0; i < pattern.Length; i++)
+                for (int i = 0; i < pattern_byte.Count; i++)
                 {
-                    Addresses[0] = SigScan.FindPattern(StringToByte(pattern[i]), mask[i], offset[i]);
+                    Addresses[0] = SigScan.FindPattern(pattern_byte[i], mask[i], offset[i]);
                     success = Addresses[0] != IntPtr.Zero;
                     
                     if (!success)

--- a/Memory/OsuModeFinder.cs
+++ b/Memory/OsuModeFinder.cs
@@ -17,7 +17,7 @@ namespace OsuRTDataProvider.Memory
         private static readonly string s_mode_mask = "xxxxxx????xxxx";
 
         private IntPtr m_mode_address;
-        private byte[] s_mode_pattern_bytes;
+        private static byte[] s_mode_pattern_bytes;
 
         public OsuPlayModeFinder(Process process) : base(process)
         {

--- a/Memory/OsuModeFinder.cs
+++ b/Memory/OsuModeFinder.cs
@@ -17,6 +17,7 @@ namespace OsuRTDataProvider.Memory
         private static readonly string s_mode_mask = "xxxxxx????xxxx";
 
         private IntPtr m_mode_address;
+        private byte[] s_mode_pattern_bytes;
 
         public OsuPlayModeFinder(Process process) : base(process)
         {
@@ -28,7 +29,7 @@ namespace OsuRTDataProvider.Memory
 
             SigScan.Reload();
             {
-                m_mode_address = SigScan.FindPattern(StringToByte(s_mode_pattern), s_mode_mask,6);
+                m_mode_address = SigScan.FindPattern(s_mode_pattern_bytes = s_mode_pattern_bytes ?? StringToByte(s_mode_pattern), s_mode_mask, 6);
                 LogHelper.LogToFile($"Mode Address (0):0x{(int)m_mode_address:X8}");
 
                 success = TryReadIntPtrFromMemory(m_mode_address, out m_mode_address);

--- a/Memory/OsuPlayFinder.cs
+++ b/Memory/OsuPlayFinder.cs
@@ -30,6 +30,11 @@ namespace OsuRTDataProvider.Memory
         private IntPtr m_time_address;
         private IntPtr m_mods_address;
 
+        private byte[] s_global_mods_pattern_bytes;
+        private byte[] s_acc_pattern_bytes;
+        private byte[] s_acc_pattern_fallback_bytes;
+        private byte[] s_time_pattern_bytes;
+
         public OsuPlayFinder(Process osu) : base(osu)
         {
         }
@@ -46,7 +51,7 @@ namespace OsuRTDataProvider.Memory
                 if (Setting.EnableModsChangedAtListening)
                 {
                     //Find mods address
-                    m_mods_address = SigScan.FindPattern(StringToByte(s_global_mods_pattern), s_global_mods_mask, 3);
+                    m_mods_address = SigScan.FindPattern(s_global_mods_pattern_bytes = s_global_mods_pattern_bytes ?? StringToByte(s_global_mods_pattern), s_global_mods_mask, 3);
                     LogHelper.LogToFile($"Mods Base Address (0):0x{(int)m_mods_address:X8}");
 
                     m_mods_address_success = TryReadIntPtrFromMemory(m_mods_address, out m_mods_address);
@@ -54,7 +59,7 @@ namespace OsuRTDataProvider.Memory
                 }
                 
                 //Find acc Address
-                m_acc_address = SigScan.FindPattern(StringToByte(s_acc_pattern), s_acc_mask, 1);
+                m_acc_address = SigScan.FindPattern(s_acc_pattern_bytes = s_acc_pattern_bytes ?? StringToByte(s_acc_pattern), s_acc_mask, 1);
                 LogHelper.LogToFile($"Playing Accuracy Base Address (0):0x{(int)m_acc_address:X8}");
 
                 m_accuracy_address_success = TryReadIntPtrFromMemory(m_acc_address, out m_acc_address);
@@ -63,7 +68,7 @@ namespace OsuRTDataProvider.Memory
                 if (!m_accuracy_address_success)//use s_acc_pattern_fallback
                 {
                     LogHelper.LogToFile("Use Fallback Accuracy Pattern");
-                    m_acc_address = SigScan.FindPattern(StringToByte(s_acc_pattern_fallback), s_acc_mask_fallback, 4);
+                    m_acc_address = SigScan.FindPattern(s_acc_pattern_fallback_bytes = s_acc_pattern_fallback_bytes ?? StringToByte(s_acc_pattern_fallback), s_acc_mask_fallback, 4);
                     LogHelper.LogToFile($"Playing Accuracy Base Address (0):0x{(int)m_acc_address:X8}");
 
                     m_accuracy_address_success = TryReadIntPtrFromMemory(m_acc_address, out m_acc_address);
@@ -71,7 +76,7 @@ namespace OsuRTDataProvider.Memory
                 }
 
                 //Find Time Address
-                m_time_address = SigScan.FindPattern(StringToByte(s_time_pattern), s_time_mask, 5);
+                m_time_address = SigScan.FindPattern(s_time_pattern_bytes = s_time_pattern_bytes ?? StringToByte(s_time_pattern), s_time_mask, 5);
                 LogHelper.LogToFile($"Time Base Address (0):0x{(int)m_time_address:X8}");
 
                 m_time_address_success = TryReadIntPtrFromMemory(m_time_address, out m_time_address);

--- a/Memory/OsuPlayFinder.cs
+++ b/Memory/OsuPlayFinder.cs
@@ -30,10 +30,10 @@ namespace OsuRTDataProvider.Memory
         private IntPtr m_time_address;
         private IntPtr m_mods_address;
 
-        private byte[] s_global_mods_pattern_bytes;
-        private byte[] s_acc_pattern_bytes;
-        private byte[] s_acc_pattern_fallback_bytes;
-        private byte[] s_time_pattern_bytes;
+        private static byte[] s_global_mods_pattern_bytes;
+        private static byte[] s_acc_pattern_bytes;
+        private static byte[] s_acc_pattern_fallback_bytes;
+        private static byte[] s_time_pattern_bytes;
 
         public OsuPlayFinder(Process osu) : base(osu)
         {

--- a/Memory/OsuStatusFinder.cs
+++ b/Memory/OsuStatusFinder.cs
@@ -11,6 +11,7 @@ namespace OsuRTDataProvider.Memory
 
         private IntPtr m_game_modes_address;
         private bool success = false;
+        private byte[] s_game_modes_pattern_bytes;
 
         public OsuStatusFinder(Process osu) : base(osu)
         {
@@ -21,7 +22,7 @@ namespace OsuRTDataProvider.Memory
             SigScan.Reload();
             {
                 //Find Game Modes
-                m_game_modes_address = SigScan.FindPattern(StringToByte(s_game_modes_pattern), s_game_modes_mask, 11);
+                m_game_modes_address = SigScan.FindPattern(s_game_modes_pattern_bytes = s_game_modes_pattern_bytes ?? StringToByte(s_game_modes_pattern), s_game_modes_mask, 11);
                 LogHelper.LogToFile($"Game Status Address (0):0x{(int)m_game_modes_address:X8}");
 
                 success = TryReadIntPtrFromMemory(m_game_modes_address, out m_game_modes_address);

--- a/Memory/OsuStatusFinder.cs
+++ b/Memory/OsuStatusFinder.cs
@@ -11,7 +11,7 @@ namespace OsuRTDataProvider.Memory
 
         private IntPtr m_game_modes_address;
         private bool success = false;
-        private byte[] s_game_modes_pattern_bytes;
+        private static byte[] s_game_modes_pattern_bytes;
 
         public OsuStatusFinder(Process osu) : base(osu)
         {

--- a/Memory/SigScan.cs
+++ b/Memory/SigScan.cs
@@ -316,7 +316,7 @@ namespace OsuRTDataProvider.Memory
             {
                 MEMORY_BASIC_INFORMATION_X64 mem_basic_info = new MEMORY_BASIC_INFORMATION_X64();
                 int mem_info_size = Marshal.SizeOf<MEMORY_BASIC_INFORMATION_X64>();
-                int size = VirtualQueryEx_X64(handle, current_address, out mem_basic_info, (uint)mem_info_size);
+                int size = VirtualQueryEx_X64(handle, current_address, ref mem_basic_info, (uint)mem_info_size);
 
                 if (size != mem_info_size)
                 {
@@ -337,7 +337,7 @@ namespace OsuRTDataProvider.Memory
             {
                 MEMORY_BASIC_INFORMATION_X86 mem_basic_info = new MEMORY_BASIC_INFORMATION_X86();
                 int mem_info_size = Marshal.SizeOf<MEMORY_BASIC_INFORMATION_X86>();
-                int size = VirtualQueryEx_X86(handle, current_address, out mem_basic_info, (uint)mem_info_size);
+                int size = VirtualQueryEx_X86(handle, current_address, ref mem_basic_info, (uint)mem_info_size);
 
                 if (size != mem_info_size)
                 {
@@ -455,10 +455,10 @@ namespace OsuRTDataProvider.Memory
             );
 
         [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "VirtualQueryEx")]
-        private static extern int VirtualQueryEx_X86(IntPtr hProcess, IntPtr lpAddress, out MEMORY_BASIC_INFORMATION_X86 lpBuffer, uint dwLength);
+        private static extern int VirtualQueryEx_X86(IntPtr hProcess, IntPtr lpAddress, ref MEMORY_BASIC_INFORMATION_X86 lpBuffer, uint dwLength);
 
         [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "VirtualQueryEx")]
-        private static extern int VirtualQueryEx_X64(IntPtr hProcess, IntPtr lpAddress, out MEMORY_BASIC_INFORMATION_X64 lpBuffer, uint dwLength);
+        private static extern int VirtualQueryEx_X64(IntPtr hProcess, IntPtr lpAddress, ref MEMORY_BASIC_INFORMATION_X64 lpBuffer, uint dwLength);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);


### PR DESCRIPTION
1. Reduce unnecessary `byte[]` allocations (avoid GC)
2. `SigScan` update: P/Invoke with `ref` instead of `out`